### PR TITLE
Execute update before applying it to the current document

### DIFF
--- a/mongokat/document.py
+++ b/mongokat/document.py
@@ -105,13 +105,13 @@ class Document(dict):
     def unset_fields(self, fields):
         """ Removes this list of fields from both the local object and the DB. """
 
-        for f in fields:
-            if f in self:
-                del self[f]
-
         self.mongokat_collection.update_one({"_id": self["_id"]}, {"$unset": {
             f: 1 for f in fields
         }})
+
+        for f in fields:
+            if f in self:
+                del self[f]
 
     def reload(self):
         """
@@ -180,14 +180,14 @@ class Document(dict):
 
         apply_on = dotdict(self)
 
+        self._initialized_with_doc = False
+
+        self.mongokat_collection.update_one({"_id": self["_id"]}, {"$set": data}, **kwargs)
+
         for k, v in data.iteritems():
             apply_on[k] = v
 
         self.update(dict(apply_on))
-
-        self._initialized_with_doc = False
-
-        self.mongokat_collection.update_one({"_id": self["_id"]}, {"$set": data}, **kwargs)
 
     def __generate_skeleton(self, doc, struct, path=""):
 

--- a/tests/sample_models.py
+++ b/tests/sample_models.py
@@ -21,7 +21,12 @@ class WithHooksDocument(Document):
     def after_delete(self, **kwargs):
         GLOBAL_HOOK_HISTORY.append(["after_delete", self["a"]])
 
-    def before_save(self, **kwargs):
+    def before_save(self, update=None, **kwargs):
+        if update is not None:
+            if (update.get("$set") or update.get("$unset") or {}).get("raise_before_save"):
+                raise Exception()
+            if update.get("$set", {}).get("incr_before_save"):
+                update["$set"]["a"] += 1
         GLOBAL_HOOK_HISTORY.append(["before_save", self["a"]])
 
     def after_save(self, **kwargs):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -30,6 +30,22 @@ def test_document_hook_save(WithHooks):
 
     assert_hooks([["before_save", 1], ["after_save", 2]])
 
+    try:
+        a1.save_partial({"a": 3, "raise_before_save": True})
+    except:
+        assert_hooks([])
+        assert a1["a"] == 2
+    else:
+        assert False
+
+    try:
+        a1.unset_fields(["a", "raise_before_save"])
+    except:
+        assert_hooks([])
+        assert a1.get("a") == 2
+    else:
+        assert False
+
     WithHooks.update({}, {"$set": {"a": 3}})
 
     assert_hooks([["before_save", 2], ["after_save", 3]])
@@ -53,6 +69,8 @@ def test_document_hook_save(WithHooks):
     WithHooks.replace_one({}, {"a": 9})
     assert_hooks([["before_save", 8], ["after_save", 9]])
 
+    WithHooks.update({}, {"$set": {"incr_before_save": True, "a": 10}})
+    assert_hooks([["before_save", 9], ["after_save", 11]])
 
 def test_document_hook_delete(WithHooks):
 


### PR DESCRIPTION
This allows any change processed by a before_save trigger to be taken into account, and it also avoids setting values that were not saved because before_save raised an exception.
