### PR TITLE
Add document_count support in Collection

### DIFF
--- a/mongokat/collection.py
+++ b/mongokat/collection.py
@@ -136,6 +136,9 @@ class Collection(object):
     def count_documents(self, *args, **kwargs):
         return self._collection_with_options(kwargs).count_documents(*args, **kwargs)
 
+    def estimated_document_count(self, **kwargs):
+        return self._collection_with_options(kwargs).estimated_document_count(**kwargs)
+
     def distinct(self, *args, **kwargs):
         return self._collection_with_options(kwargs).distinct(*args, **kwargs)
 

--- a/mongokat/collection.py
+++ b/mongokat/collection.py
@@ -133,6 +133,9 @@ class Collection(object):
     def count(self, *args, **kwargs):
         return self._collection_with_options(kwargs).count(*args, **kwargs)
 
+    def count_documents(self, *args, **kwargs):
+        return self._collection_with_options(kwargs).count_documents(*args, **kwargs)
+
     def distinct(self, *args, **kwargs):
         return self._collection_with_options(kwargs).distinct(*args, **kwargs)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,12 +89,14 @@ def test_document_common_methods(Sample):
   import collections
 
   assert Sample.collection.find().count() == 0
+  assert Sample.collection.find().count_documents({}) == 0
 
   # Instanciate
   new_object = Sample({"name": "XXX", "url": "http://example.com"})
 
   # Should not save to DB yet.
   assert Sample.collection.find().count() == 0
+  assert Sample.collection.find().count_documents({}) == 0
 
   # Now save()
   new_object.save()
@@ -106,6 +108,7 @@ def test_document_common_methods(Sample):
   assert type(new_object["_id"]) == ObjectId
 
   assert Sample.collection.find().count() == 1
+  assert Sample.collection.find().count_documents({}) == 1
   db_object = Sample.collection.find_one()
   assert type(db_object) == dict
   assert db_object["name"] == "XXX"
@@ -115,6 +118,7 @@ def test_document_common_methods(Sample):
   assert type(inserted_object) == ObjectId
 
   assert Sample.collection.find().count() == 2
+  assert Sample.collection.find().count_documents({}) == 2
 
   # Find back with different methods
   orm_object = Sample.find_by_id(db_object["_id"])
@@ -168,11 +172,13 @@ def test_document_common_methods(Sample):
     orm_object.save()
 
   assert Sample.collection.find().count() == 2
+  assert Sample.collection.find().count_documents({}) == 2
 
   # FIXME not anymore as we are requesting _id for each query
   # orm_object.save(force=True)
 
   # assert Sample.collection.find().count() == 3
+  # assert Sample.collection.find().count_documents({}) == 3
 
   orm_object = Sample.find_by_id(db_object["_id"], fields=["url", "_id"])
   assert dict(orm_object) == {"url": "http://example.com", "_id": db_object["_id"]}
@@ -186,6 +192,8 @@ def test_document_common_methods(Sample):
     orm_object.save()
 
   assert Sample.collection.find().count() == 2
+  assert Sample.collection.find().count_documents({}) == 2
+
   db_object = Sample.collection.find_one({"_id": db_object["_id"]})
   assert "name" in db_object
 
@@ -193,6 +201,7 @@ def test_document_common_methods(Sample):
 
   # Should not add anything new
   assert Sample.collection.find().count() == 2
+  assert Sample.collection.find().count_documents({}) == 2
 
   db_object = Sample.collection.find_one({"_id": db_object["_id"]})
   assert "name" not in db_object

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,6 +90,7 @@ def test_document_common_methods(Sample):
 
   assert Sample.collection.find().count() == 0
   assert Sample.collection.find().count_documents({}) == 0
+  assert Sample.collection.find().estimated_document_count() == 0
 
   # Instanciate
   new_object = Sample({"name": "XXX", "url": "http://example.com"})
@@ -97,6 +98,7 @@ def test_document_common_methods(Sample):
   # Should not save to DB yet.
   assert Sample.collection.find().count() == 0
   assert Sample.collection.find().count_documents({}) == 0
+  assert Sample.collection.find().estimated_document_count() == 0
 
   # Now save()
   new_object.save()
@@ -109,6 +111,7 @@ def test_document_common_methods(Sample):
 
   assert Sample.collection.find().count() == 1
   assert Sample.collection.find().count_documents({}) == 1
+  assert Sample.collection.find().estimated_document_count() == 1
   db_object = Sample.collection.find_one()
   assert type(db_object) == dict
   assert db_object["name"] == "XXX"
@@ -119,6 +122,7 @@ def test_document_common_methods(Sample):
 
   assert Sample.collection.find().count() == 2
   assert Sample.collection.find().count_documents({}) == 2
+  assert Sample.collection.find().estimated_document_count() == 2
 
   # Find back with different methods
   orm_object = Sample.find_by_id(db_object["_id"])
@@ -173,12 +177,14 @@ def test_document_common_methods(Sample):
 
   assert Sample.collection.find().count() == 2
   assert Sample.collection.find().count_documents({}) == 2
+  assert Sample.collection.find().estimated_document_count() == 2
 
   # FIXME not anymore as we are requesting _id for each query
   # orm_object.save(force=True)
 
   # assert Sample.collection.find().count() == 3
   # assert Sample.collection.find().count_documents({}) == 3
+  # assert Sample.collection.find().estimated_document_count() == 3
 
   orm_object = Sample.find_by_id(db_object["_id"], fields=["url", "_id"])
   assert dict(orm_object) == {"url": "http://example.com", "_id": db_object["_id"]}
@@ -193,6 +199,7 @@ def test_document_common_methods(Sample):
 
   assert Sample.collection.find().count() == 2
   assert Sample.collection.find().count_documents({}) == 2
+  assert Sample.collection.find().estimated_document_count() == 2
 
   db_object = Sample.collection.find_one({"_id": db_object["_id"]})
   assert "name" in db_object
@@ -202,6 +209,7 @@ def test_document_common_methods(Sample):
   # Should not add anything new
   assert Sample.collection.find().count() == 2
   assert Sample.collection.find().count_documents({}) == 2
+  assert Sample.collection.find().estimated_document_count() == 2
 
   db_object = Sample.collection.find_one({"_id": db_object["_id"]})
   assert "name" not in db_object


### PR DESCRIPTION
Hello,

I have noticed that pymongo version 3.7.2 logs warnings when the `collection.count()` method is called:
> count is deprecated. Use Collection.count_documents instead.
The topic is discussed in more details in [this stackoverflow thread](https://stackoverflow.com/questions/57114934/what-to-use-instead-of-count-with-cursor) and in [this other thread](https://stackoverflow.com/a/54759357) as well.

To solve the problem, I have just added a `count_collection()` and an `estimated_document_count()` method to mongokat's collection class, wrapping around the pymongo methods. 
Would you be okay with merging these small changes ?  

Thanks !